### PR TITLE
chore: publish fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,7 @@ npm run build && npm run serve
 You can use the watch scripts in the `plugin-docusaurus` package to recompile the source code for the plugin.
 
 If you need search results you will need to re-run the docusaurus build and serve commands every time you make a change to the plugin. If you don't need search results you can just run `npm start` in the `website` plus whichever watch scripts you need from the plugin and you will get hot reloads in the docusaurus app.
+
+# License
+
+Licensed under the [Apache 2.0](/LICENSE.md) license.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lyrasearch/plugin-docusaurus",
-  "version": "0.0.1-beta.1",
+  "version": "0.0.0",
   "private": true,
   "workspaces": [
     "website",
@@ -10,12 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/lyrasearch/plugin-docusaurus.git"
   },
-  "files": [
-    "/src",
-    "/translationMessages",
-    "/README.md"
-  ],
-  "license": "MIT",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/lyrasearch/plugin-docusaurus/issues"
   },

--- a/plugin-docusaurus/package.json
+++ b/plugin-docusaurus/package.json
@@ -28,7 +28,7 @@
     "docusaurus"
   ],
   "author": "",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/lyrasearch/plugin-docusaurus/issues"
   },


### PR DESCRIPTION
Changes in package.json for both root and plugin.

* License changed to MIT
* files removed from root's package.json

_NOTE_: We should decide if we want to move the docs to Lyra's documentation.